### PR TITLE
Zonnsmart TRVs from updated ZHA

### DIFF
--- a/ts0601_trv_zonnsmart.py
+++ b/ts0601_trv_zonnsmart.py
@@ -168,9 +168,16 @@ class ZonnsmartTV01_ZG(TuyaThermostat):
         #  endpoint=1 profile=260 device_type=81 device_version=0 input_clusters=[0, 4, 5, 61184]
         #  output_clusters=[10, 25]>
         MODELS_INFO: [
-            ("_TZE200_e9ba97vf", "TS0601"),
-            ("_TZE200_husqqvux", "TS0601"),
-            ("_TZE200_kly8gjlz", "TS0601"),
+            ("_TZE200_7yoranx2", "TS0601"),  # MOES TV01 ZTRV-ZX-TV01-MS
+            ("_TZE200_e9ba97vf", "TS0601"),  # Zonnsmart TV01-ZG
+            ("_TZE200_hue3yfsn", "TS0601"),  # Zonnsmart TV02-ZG
+            ("_TZE200_husqqvux", "TS0601"),  # Tesla Smart TSL-TRV-TV01ZG
+            ("_TZE200_kly8gjlz", "TS0601"),  # EARU TV05-ZG
+            ("_TZE200_lnbfnyxd", "TS0601"),  # Tesla Smart TSL-TRV-TV01ZG
+            ("_TZE200_mudxchsu", "TS0601"),  # Foluu TV05
+            ("_TZE200_kds0pmmv", "TS0601"),  # MOES TV02
+            ("_TZE200_sur6q7ko", "TS0601"),  # LSC Smart Connect 3012732
+            ("_TZE200_lllliz3p", "TS0601"),  # tuya TV02-Zigbee
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
I cant grantee that all is 100% Zonnsmart compatible but most is in Z2M and some is user requests in ZHA.