### PR TITLE
add support for ME168

### DIFF
--- a/ts0601_trv_me167.py
+++ b/ts0601_trv_me167.py
@@ -443,6 +443,8 @@ class ME167(TuyaThermostat):
         MODELS_INFO: [
             ("_TZE200_bvu2wnxz", "TS0601"),
             ("_TZE200_6rdj8dzm", "TS0601"),
+            ("_TZE200_p3dbf6qs", "TS0601"), # model: 'ME168', vendor: 'Avatto'
+            ("_TZE200_rxntag7i", "TS0601"), # model: 'ME168', vendor: 'Avatto'
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
add support for ME168, tested on  _TZE200_rxntag7i

see also https://github.com/dyx052612/zigbee-herdsman-converters/blob/b2918cdd1da093e90c5753b4b0fb5af06e21f009/src/devices/tuya.ts

binding should be the same, ME168 supports schedule in addition to 167