### PR TITLE
Add model info `_TZE200_2cs6g9i7` for Sitewell / Brennenstuhl trv

### DIFF
--- a/ts0601_trv_siterwell.py
+++ b/ts0601_trv_siterwell.py
@@ -774,6 +774,7 @@ class SiterwellGS361_Type2(TuyaThermostat):
             ("_TZE200_ps5v5jor", "TS0601"),
             ("_TZE200_owwdxjbx", "TS0601"),
             ("_TZE200_8daqwrsj", "TS0601"),
+            ("_TZE200_2cs6g9i7", "TS0601"), # Brennenstuhl HT CZ 01
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Thank you for your collection of quirks, which I have been using unaware of your repository. Only recently, due to the breaking change in Home Assistant 2023.7, I became aware of your repo.

I have added a model info for [Brennenstuhl HT CZ 01](https://www.zigbee2mqtt.io/devices/GS361A-H04.html).