### PR TITLE
Update ts0601_trv_rtitek2.py

### DIFF
--- a/ts0601_trv_rtitek2.py
+++ b/ts0601_trv_rtitek2.py
@@ -675,6 +675,10 @@ class Rti2(TuyaThermostat):
         #  output_clusters=[10, 25]>
         MODELS_INFO: [
             ("_TZE200_bvrlmajk", "TS0601"),
+            #MOES TRV
+            ("_TZE204_9mjy74mp", "TS0601"),
+            ("_TZE200_9mjy74mp", "TS0601"),
+            ("_TZE200_rtrmfadk", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
added the moes TRV models that works with this quirk.

https://moeshouse.com/products/smart-wifi-thermostatic-radiator-valve-trv-programmable-temperature-controller?variant=49598375231803

you might wanna add them ts0601_trv_rtitek2.py  as wel since they work in that quirk also.