### PR TITLE
Update ts0601_trv_rtitek.py

### DIFF
--- a/ts0601_trv_rtitek.py
+++ b/ts0601_trv_rtitek.py
@@ -735,7 +735,11 @@ class Rti(TuyaThermostat):
             ("_TZE200_a4bpgplm", "TS0601"),
             ("_TZE200_dv8abrrz", "TS0601"),
             ("_TZE200_z1tyspqw", "TS0601"),
+            #moes trv 
+            ("_TZE204_9mjy74mp", "TS0601"),
+            ("_TZE200_9mjy74mp", "TS0601"),
             ("_TZE200_rtrmfadk", "TS0601"),
+            
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
added
            ("_TZE204_9mjy74mp", "TS0601"),
            ("_TZE200_9mjy74mp", "TS0601"),
            ("_TZE200_rtrmfadk", "TS0601"),
since they work in this quirk aswell

https://moeshouse.com/products/smart-wifi-thermostatic-radiator-valve-trv-programmable-temperature-controller?variant=49598375231803