### PR TITLE
Device Support: 'N-TRV16', vendor: 'Avatto'; "_TZE204_vjpaih9f", "TS0601"

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ logger:
             ("_TZE200_rxntag7i", "TS0601"), # model: 'ME168', vendor: 'Avatto'
             ("_TZE200_rxq4iti9", "TS0601"),
             ("_TZE200_9xfjixap", "TS0601"),
+            ("_TZE200_ow09xlxm", "TS0601"),  # model: 'TRV06-AT', vendor: 'Thaleos'
+            ("_TZE204_vjpaih9f", "TS0601"),  # model: 'N-TRV16', vendor: 'Avatto'
         ],
 ```
 ## ts0601_trv_moes.py

--- a/ts0601_trv_me167.py
+++ b/ts0601_trv_me167.py
@@ -475,6 +475,7 @@ class ME167(TuyaThermostat):
             ("_TZE200_rxq4iti9", "TS0601"),
             ("_TZE200_9xfjixap", "TS0601"),
             ("_TZE200_ow09xlxm", "TS0601"),  # model: 'TRV06-AT', vendor: 'Thaleos'
+            ("_TZE204_vjpaih9f", "TS0601"),  # model: 'N-TRV16', vendor: 'Avatto'
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
Added support:

("_TZE204_vjpaih9f", "TS0601"),  # model: 'N-TRV16', vendor: 'Avatto'


Device Signature:
``` YAML
{
  "node_descriptor": {
    "logical_type": 2,
    "complex_descriptor_available": 0,
    "user_descriptor_available": 0,
    "reserved": 0,
    "aps_flags": 0,
    "frequency_band": 8,
    "mac_capability_flags": 128,
    "manufacturer_code": 4417,
    "maximum_buffer_size": 66,
    "maximum_incoming_transfer_size": 66,
    "server_mask": 10752,
    "maximum_outgoing_transfer_size": 66,
    "descriptor_capability_field": 0
  },
  "endpoints": {
    "1": {
      "profile_id": "0x0104",
      "device_type": "0x0051",
      "input_clusters": [
        "0x0000",
        "0x0004",
        "0x0005",
        "0xef00"
      ],
      "output_clusters": [
        "0x000a",
        "0x0019"
      ]
    }
  },
  "manufacturer": "_TZE204_vjpaih9f",
  "model": "TS0601",
  "class": "zigpy.device.Device"
}
```