### PR TITLE
Clean up server_commands by removing False values

### DIFF
--- a/ts0601_thermostat_avatto.py
+++ b/ts0601_thermostat_avatto.py
@@ -164,19 +164,16 @@ class AvattoManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=False,
         ),
     }

--- a/ts0601_thermostat_avatto2.py
+++ b/ts0601_thermostat_avatto2.py
@@ -164,19 +164,16 @@ class Avatto2ManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=True,
         ),
     }

--- a/ts0601_thermostat_electsmart.py
+++ b/ts0601_thermostat_electsmart.py
@@ -166,19 +166,16 @@ class ElectsmartManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=False,
         ),
     }

--- a/ts0601_trv_beca.py
+++ b/ts0601_trv_beca.py
@@ -85,19 +85,16 @@ class BecaManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=True,
         ),
     }

--- a/ts0601_trv_maxsmart.py
+++ b/ts0601_trv_maxsmart.py
@@ -450,19 +450,16 @@ class Silvercrest3ManufCluster(MaxsmartManufCluster):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=False,
         ),
     }

--- a/ts0601_trv_me167.py
+++ b/ts0601_trv_me167.py
@@ -165,19 +165,16 @@ class ME167ManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=True,
         ),
     }

--- a/ts0601_trv_rtitek.py
+++ b/ts0601_trv_rtitek.py
@@ -165,19 +165,16 @@ class RtiManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=False,
         ),
     }

--- a/ts0601_trv_rtitek2.py
+++ b/ts0601_trv_rtitek2.py
@@ -163,19 +163,16 @@ class Rti2ManufCluster(TuyaManufClusterAttributes):
         0x0000: foundation.ZCLCommandDef(
             "set_data",
             {"param": TuyaManufCluster.Command},
-            False,
             is_manufacturer_specific=False,
         ),
         0x0010: foundation.ZCLCommandDef(
             "mcu_version_req",
             {"param": t.uint16_t},
-            False,
             is_manufacturer_specific=True,
         ),
         0x0024: foundation.ZCLCommandDef(
             "set_time",
             {"param": TuyaTimePayload},
-            False,
             is_manufacturer_specific=False,
         ),
     }


### PR DESCRIPTION
Removes the following warning in HA: 

Command 'mcu_version_req' has an incorrect direction, please remove the  kwarg Command 'set_data' has an incorrect direction, please remove the  kwarg Command 'set_time' has an incorrect direction, please remove the  kwarg